### PR TITLE
Added new resource file system

### DIFF
--- a/app/src/main/java/com/trianguloy/urlchecker/modules/companions/ResourceCatalogs/AutoUpdateableResource.java
+++ b/app/src/main/java/com/trianguloy/urlchecker/modules/companions/ResourceCatalogs/AutoUpdateableResource.java
@@ -1,0 +1,71 @@
+package com.trianguloy.urlchecker.modules.companions.ResourceCatalogs;
+
+import android.util.Log;
+
+import com.trianguloy.urlchecker.R;
+import com.trianguloy.urlchecker.utilities.generics.GenericPref;
+import com.trianguloy.urlchecker.utilities.methods.JavaUtils;
+
+public class AutoUpdateableResource<T> extends UpdateableResource<T> {
+    protected final int AUTOUPDATE_PERIOD;
+    protected final GenericPref.Bool autoUpdate;
+    protected final GenericPref.Bool lastAuto;
+
+    public AutoUpdateableResource(BuiltInResource<T> builtIn,
+                                  String modifiableFile,
+                                  String key,
+                                  String catalogUrlDefault,
+                                  String hashUrlDefault,
+                                  long lastUpdateDefault,
+                                  int autoUpdatePeriod) {
+        super(builtIn, modifiableFile, key, catalogUrlDefault, hashUrlDefault, lastUpdateDefault);
+        var context = getContext();
+
+        this.autoUpdate = new GenericPref.Bool(key + "_autoUpdate", false, context);
+        this.lastAuto = new GenericPref.Bool(key + "_lastAuto", false, context);
+        this.AUTOUPDATE_PERIOD = autoUpdatePeriod;
+
+        updateIfNecessary();
+    }
+
+    /* ------------------- ui ------------------- */
+
+    @Override
+    public void updateText() {
+        super.updateText();
+        var context = getContext();
+        JavaUtils.ifPresent(txt_check, () ->
+                txt_check.append((lastAuto.get() ? " [" + context.getString(R.string.auto) + "]" : "")));
+    }
+
+    // ------------------- internal -------------------
+
+    @Override
+    public void _update(boolean background) {
+        lastAuto.set(background);   // If called from background, then it must be automatic
+        super._update(background);
+    }
+
+    /**
+     * If the catalog is old, updates it in background. Otherwise does nothing.
+     */
+    private void updateIfNecessary() {
+        var context = getContext();
+        if (autoUpdate.get() && lastUpdate.get() + AUTOUPDATE_PERIOD < System.currentTimeMillis()) {
+            new Thread(() -> {
+                // run
+                lastAuto.set(true);
+                var code = _updateResource();
+
+                // don't show message to user, but log it
+                Log.d("UPDATE", context.getString(code.getStringResource()));
+            }).start();
+        }
+    }
+
+    @Override
+    public void clear() {
+        lastAuto.clear();
+        super.clear();
+    }
+}

--- a/app/src/main/java/com/trianguloy/urlchecker/modules/companions/ResourceCatalogs/BuiltInResource.java
+++ b/app/src/main/java/com/trianguloy/urlchecker/modules/companions/ResourceCatalogs/BuiltInResource.java
@@ -1,0 +1,65 @@
+package com.trianguloy.urlchecker.modules.companions.ResourceCatalogs;
+
+import android.app.Activity;
+
+public abstract class BuiltInResource<T> implements ResourceGuideInterface<T>, ResourceContextInterface {
+    protected final Activity context;
+    protected final ResourceGuide<T> type;
+
+    /**
+     * @param context Can't be null
+     */
+    public BuiltInResource(Activity context, ResourceGuide<T> resource) {
+        this.context = context;
+        this.type = resource;
+    }
+
+    /**
+     * Gets the builtin catalog
+     */
+    public T getBuiltIn() {
+        try {
+            return buildBuiltIn();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return getEmpty();
+        }
+    }
+
+    /**
+     * Builds the builtin catalog
+     *
+     * @implNote For dynamically building, just extend this class and override the method.
+     * For file reading, refer to {@link BuiltInResourceFile}.
+     */
+    protected abstract T buildBuiltIn() throws Exception;
+
+    public Activity getContext() {
+        return context;
+    }
+
+    // ------------------- delegation -------------------
+
+    /**
+     * @implNote Can be overridden for a more specific implementation.
+     */
+    @Override
+    public T getEmpty() {
+        return type.getEmpty();
+    }
+
+    @Override
+    public T toObject(String string) {
+        return type.toObject(string);
+    }
+
+    @Override
+    public T toObjectThrows(String string) throws Exception {
+        return type.toObjectThrows(string);
+    }
+
+    @Override
+    public String toString(T object) {
+        return type.toString(object);
+    }
+}

--- a/app/src/main/java/com/trianguloy/urlchecker/modules/companions/ResourceCatalogs/BuiltInResourceFile.java
+++ b/app/src/main/java/com/trianguloy/urlchecker/modules/companions/ResourceCatalogs/BuiltInResourceFile.java
@@ -1,0 +1,24 @@
+package com.trianguloy.urlchecker.modules.companions.ResourceCatalogs;
+
+import android.app.Activity;
+
+import com.trianguloy.urlchecker.utilities.wrappers.AssetFile;
+
+import java.io.FileNotFoundException;
+
+public class BuiltInResourceFile<T> extends BuiltInResource<T> {
+    protected final AssetFile readOnlyFile;
+
+    public BuiltInResourceFile(Activity context, ResourceGuide<T> type, String fileName) {
+        super(context, type);
+        this.readOnlyFile = new AssetFile(fileName, context);
+    }
+
+    @Override
+    protected T buildBuiltIn() throws Exception {
+        // read internal file
+        String builtIn = this.readOnlyFile.get();
+        if (builtIn != null) return type.toObjectThrows(builtIn);
+        throw new FileNotFoundException();
+    }
+}

--- a/app/src/main/java/com/trianguloy/urlchecker/modules/companions/ResourceCatalogs/JsonGuide.java
+++ b/app/src/main/java/com/trianguloy/urlchecker/modules/companions/ResourceCatalogs/JsonGuide.java
@@ -1,0 +1,25 @@
+package com.trianguloy.urlchecker.modules.companions.ResourceCatalogs;
+
+import com.trianguloy.urlchecker.utilities.methods.JavaUtils;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class JsonGuide extends ResourceGuide<JSONObject> {
+
+    @Override
+    public JSONObject getEmpty() {
+        // FIXME: new JSONObject() instead?
+        return JavaUtils.toJson("{\"empty\":{}}");
+    }
+
+    @Override
+    public JSONObject toObjectThrows(String string) throws JSONException {
+        return new JSONObject(string);
+    }
+
+    @Override
+    public String toString(JSONObject object) {
+        return object.toString();
+    }
+}

--- a/app/src/main/java/com/trianguloy/urlchecker/modules/companions/ResourceCatalogs/ManualEditResource.java
+++ b/app/src/main/java/com/trianguloy/urlchecker/modules/companions/ResourceCatalogs/ManualEditResource.java
@@ -1,0 +1,23 @@
+package com.trianguloy.urlchecker.modules.companions.ResourceCatalogs;
+
+public class ManualEditResource<T> extends ModifiableResource<T> {
+    public ManualEditResource(BuiltInResource<T> builtIn, String modifiableFile) {
+        super(builtIn, modifiableFile);
+    }
+
+    /**
+     * Saves the new content to a file
+     */
+    public boolean save(T newContent) {
+        String neww = toString(newContent);
+        String builtin = toString(builtIn.getBuiltIn());
+        // same as builtin (maybe a reset?), delete custom
+        if (neww.equals(builtin)) {
+            writableFile.delete();
+            return true;
+        }
+
+        // store
+        return writableFile.set(neww);
+    }
+}

--- a/app/src/main/java/com/trianguloy/urlchecker/modules/companions/ResourceCatalogs/ModifiableResource.java
+++ b/app/src/main/java/com/trianguloy/urlchecker/modules/companions/ResourceCatalogs/ModifiableResource.java
@@ -1,0 +1,58 @@
+package com.trianguloy.urlchecker.modules.companions.ResourceCatalogs;
+
+import android.app.Activity;
+
+import com.trianguloy.urlchecker.utilities.wrappers.InternalFile;
+
+public abstract class ModifiableResource<T> implements ResourceGuideInterface<T>, ResourceContextInterface {
+    protected final BuiltInResource<T> builtIn;
+    protected final InternalFile writableFile;
+
+
+    public ModifiableResource(BuiltInResource<T> builtIn,
+                              String modifiableFile) {
+        this.builtIn = builtIn;
+
+        this.writableFile = new InternalFile(modifiableFile, getContext());
+    }
+
+    public T getCatalog() {
+        // get the updated file first
+        String internal = writableFile.get();
+        if (internal != null) return toObject(internal);
+
+        // no updated file or can't read, use built-in one
+        return builtIn.getBuiltIn();
+    }
+
+    public void clear() {
+        writableFile.delete();
+    }
+
+    // ------------------- delegation -------------------
+
+    @Override
+    public Activity getContext() {
+        return builtIn.getContext();
+    }
+
+    @Override
+    public String toString(T object) {
+        return builtIn.toString(object);
+    }
+
+    @Override
+    public T toObject(String string) {
+        return builtIn.toObject(string);
+    }
+
+    @Override
+    public T toObjectThrows(String string) throws Exception {
+        return builtIn.toObjectThrows(string);
+    }
+
+    @Override
+    public T getEmpty() {
+        return builtIn.getEmpty();
+    }
+}

--- a/app/src/main/java/com/trianguloy/urlchecker/modules/companions/ResourceCatalogs/ResourceContextInterface.java
+++ b/app/src/main/java/com/trianguloy/urlchecker/modules/companions/ResourceCatalogs/ResourceContextInterface.java
@@ -1,0 +1,7 @@
+package com.trianguloy.urlchecker.modules.companions.ResourceCatalogs;
+
+import android.app.Activity;
+
+public interface ResourceContextInterface {
+    Activity getContext();
+}

--- a/app/src/main/java/com/trianguloy/urlchecker/modules/companions/ResourceCatalogs/ResourceGuide.java
+++ b/app/src/main/java/com/trianguloy/urlchecker/modules/companions/ResourceCatalogs/ResourceGuide.java
@@ -1,0 +1,24 @@
+package com.trianguloy.urlchecker.modules.companions.ResourceCatalogs;
+
+public abstract class ResourceGuide<T> implements ResourceGuideInterface<T> {
+    /**
+     * Fallbacks to {@link #getEmpty()}
+     */
+    public T toObject(String string) {
+        try {
+            return toObjectThrows(string);
+        } catch (Exception e) {
+            // invalid, return empty
+            return getEmpty();
+        }
+    }
+
+    @Override
+    public abstract T toObjectThrows(String string) throws Exception;
+
+    @Override
+    public abstract String toString(T object);
+
+    @Override
+    public abstract T getEmpty();
+}

--- a/app/src/main/java/com/trianguloy/urlchecker/modules/companions/ResourceCatalogs/ResourceGuideInterface.java
+++ b/app/src/main/java/com/trianguloy/urlchecker/modules/companions/ResourceCatalogs/ResourceGuideInterface.java
@@ -1,0 +1,11 @@
+package com.trianguloy.urlchecker.modules.companions.ResourceCatalogs;
+
+public interface ResourceGuideInterface<T> {
+    T toObject(String string);
+
+    T toObjectThrows(String string) throws Exception;
+
+    String toString(T object);
+
+    T getEmpty();
+}

--- a/app/src/main/java/com/trianguloy/urlchecker/modules/companions/ResourceCatalogs/UpdateResult.java
+++ b/app/src/main/java/com/trianguloy/urlchecker/modules/companions/ResourceCatalogs/UpdateResult.java
@@ -1,0 +1,27 @@
+package com.trianguloy.urlchecker.modules.companions.ResourceCatalogs;
+
+import com.trianguloy.urlchecker.R;
+import com.trianguloy.urlchecker.utilities.Enums;
+
+public enum UpdateResult implements Enums.StringEnum {
+    // TODO: rename strings
+    URL_ERROR(R.string.mClear_urlError),
+    HASH_ERROR(R.string.mClear_hashError),
+    HASH_MISMATCH(R.string.mClear_hashMismatch),
+    INVALID(R.string.toast_invalid),
+    UPDATED(R.string.mClear_updated),
+    UP_TO_DATE(R.string.mClear_upToDate),
+    ERROR(R.string.mClear_error);
+
+    private final int string;
+
+    UpdateResult(int string) {
+        this.string = string;
+    }
+
+
+    @Override
+    public int getStringResource() {
+        return string;
+    }
+}

--- a/app/src/main/java/com/trianguloy/urlchecker/modules/companions/ResourceCatalogs/UpdateableResource.java
+++ b/app/src/main/java/com/trianguloy/urlchecker/modules/companions/ResourceCatalogs/UpdateableResource.java
@@ -1,0 +1,172 @@
+package com.trianguloy.urlchecker.modules.companions.ResourceCatalogs;
+
+import android.util.Log;
+import android.widget.Button;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import com.trianguloy.urlchecker.utilities.generics.GenericPref;
+import com.trianguloy.urlchecker.utilities.methods.AndroidUtils;
+import com.trianguloy.urlchecker.utilities.methods.HttpUtils;
+import com.trianguloy.urlchecker.utilities.methods.JavaUtils;
+import com.trianguloy.urlchecker.utilities.methods.StreamUtils;
+
+import java.io.IOException;
+
+public class UpdateableResource<T> extends ModifiableResource<T> implements ResourceGuideInterface<T>, ResourceContextInterface {
+    /* ------------------- prefs ------------------- */
+
+    protected final GenericPref.Str catalogURL;
+    protected final GenericPref.Str hashURL;
+    protected final GenericPref.Lng lastUpdate;
+    protected final GenericPref.Lng lastCheck;
+
+    /* ------------------- constructor ------------------- */
+
+    public UpdateableResource(BuiltInResource<T> builtIn,
+                              String modifiableFile,
+                              String key,
+                              String catalogUrlDefault,
+                              String hashUrlDefault,
+                              long lastUpdateDefault) {
+        super(builtIn, modifiableFile);
+
+        this.catalogURL = new GenericPref.Str(key + "_catalogURL", catalogUrlDefault, getContext());
+        this.hashURL = new GenericPref.Str(key + "_hashURL", hashUrlDefault, getContext());
+        this.lastUpdate = new GenericPref.Lng(key + "lastUpdate", lastUpdateDefault, getContext());
+        this.lastCheck = new GenericPref.Lng(key + "lastCheck", -1L, getContext());
+    }
+
+    // ------------------- ui -------------------
+
+    Button updateButton;
+    TextView txt_check;
+    TextView txt_update;
+
+
+    public void attachToUpdateButton(Button button) {
+        this.updateButton = button;
+        updateButton.setOnClickListener(v -> {
+            _update(false);
+        });
+    }
+
+    public void attachToCheckText(TextView text) {
+        this.txt_check = text;
+    }
+
+    public void attachToUpdateText(TextView text) {
+        this.txt_update = text;
+    }
+
+    public void updateText() {
+        var context = getContext();
+        JavaUtils.ifPresent(txt_check, () ->
+                txt_check.setText(AndroidUtils.formatMillis(lastCheck.get(), context)));
+        JavaUtils.ifPresent(txt_update, () ->
+                txt_update.setText(AndroidUtils.formatMillis(lastUpdate.get(), context)));
+    }
+
+    // ------------------- internal -------------------
+    @Override
+    public void clear() {
+        lastUpdate.clear();
+        lastCheck.clear();
+        super.clear();
+    }
+
+    public void _update(boolean background) {
+        if (!background) {
+            JavaUtils.ifPresent(updateButton, () -> updateButton.setEnabled(false));
+        }
+        var context = getContext();
+        new Thread(() -> {
+            // run
+            var code = _updateResource();
+
+            if (background) {
+                Log.d("UPDATE", context.getString(code.getStringResource()));
+            } else {
+                context.runOnUiThread(() -> {
+                    JavaUtils.ifPresent(updateButton, () -> updateButton.setEnabled(true));
+                    updateText();  // text listeners
+                    Toast.makeText(context, code.getStringResource(), Toast.LENGTH_SHORT).show();
+                });
+            }
+        }).start();
+    }
+
+    /**
+     * Replaces the resource with a new one.
+     * Network operation, designed to be run in a background thread.
+     * Returns the message to display to the user about the result
+     */
+    protected UpdateResult _updateResource() {
+        long now = System.currentTimeMillis();
+        lastCheck.set(now);
+        // read content
+        String rawContent;
+        try {
+            rawContent = HttpUtils.readFromUrl(catalogURL.get());
+        } catch (IOException e) {
+            e.printStackTrace();
+            return UpdateResult.URL_ERROR;
+        }
+
+        // check hash if provided
+        if (!hashURL.get().trim().isEmpty()) {
+
+            // read hash
+            String hash;
+            try {
+                hash = HttpUtils.readFromUrl(hashURL.get()).trim();
+            } catch (IOException e) {
+                e.printStackTrace();
+                return UpdateResult.HASH_ERROR;
+            }
+
+            // if different, notify
+            if (!StreamUtils.sha256(rawContent).equalsIgnoreCase(hash)) {
+                return UpdateResult.HASH_MISMATCH;
+            }
+        }
+
+        // valid, save and update
+        var res = _save(rawContent);
+        if (res == UpdateResult.UPDATED) {
+            lastUpdate.set(now);
+        }
+        return res;
+    }
+
+    /**
+     * Saves a new local file. Returns if it was up to date, updated or an error happened.
+     */
+    private UpdateResult _save(String rawContent) {
+        // parse
+        T content;
+        try {
+            content = toObjectThrows(rawContent);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return UpdateResult.INVALID;
+        }
+
+        // Compact
+        String string = toString(content);
+
+        // nothing changed, nothing to update
+        if (string.equals(getCatalog().toString())) {
+            return UpdateResult.UP_TO_DATE;
+        }
+
+        // same as builtin (probably a reset), clear custom
+        if (string.equals(toString(builtIn.getBuiltIn()))) {
+            clear();
+            return UpdateResult.UPDATED;
+        }
+
+        // something new, save
+        return writableFile.set(string) ? UpdateResult.UPDATED : UpdateResult.ERROR;
+    }
+}

--- a/app/src/main/java/com/trianguloy/urlchecker/utilities/methods/JavaUtils.java
+++ b/app/src/main/java/com/trianguloy/urlchecker/utilities/methods/JavaUtils.java
@@ -100,6 +100,16 @@ public interface JavaUtils {
     }
 
     /**
+     * Calls the function if obj is not null
+     * java.util.Optional requires api 24
+     */
+    static <T> void ifPresent(T obj, Runnable func){
+        if (obj != null){
+            func.run();
+        }
+    }
+
+    /**
      * if the element is present in the list, removes it
      * if not, adds it
      */
@@ -136,5 +146,40 @@ public interface JavaUtils {
      */
     @FunctionalInterface
     interface UnaryOperator<T> extends Function<T, T> {
+    }
+
+    /**
+     * java.time.Duration requires api 26
+     */
+    static int weeksToMillis(int weeks){
+        return weeks*daysToMillis(7);
+    }
+
+    /**
+     * java.time.Duration requires api 26
+     */
+    static int daysToMillis(int days){
+        return days*hoursToMillis(24);
+    }
+
+    /**
+     * java.time.Duration requires api 26
+     */
+    static int hoursToMillis(int hours){
+        return hours*minutesToMillis(60);
+    }
+
+    /**
+     * java.time.Duration requires api 26
+     */
+    static int minutesToMillis(int minutes){
+        return minutes*secondsToMillis(60);
+    }
+
+    /**
+     * java.time.Duration requires api 26
+     */
+    static int secondsToMillis(int seconds){
+        return seconds*1000;
     }
 }


### PR DESCRIPTION
So, I was going to do a Privacy redirector module as per #7. But I noticed all the logic to download files is in `ClearUrlCatalog.java`, to avoid code duplication I got sidetracked working on this.
This is the, 4th(? or 3rd, I don't remember) iteration, but the code is still untested, I don't want to spend more time than necessary in something that might not be merged, althought it _should_ work as it is mainly refactoring.

Here is the class diagram to make things clearer at a glance. I have omitted certain things so it is easier to follow
The main thing to worry is the diagonal of abstract classes as each relies on the previous.
```mermaid

classDiagram
    class ResourceContextInterface{
        <<interface>>
        +getContext() Activity
    }

    class ResourceGuideInterface~T~{
        <<interface>>
        +toObject(String content) T
        +toObjectThrows(String content) T
        +toString(T) String
        +getEmpty() T
    }
    ResourceGuideInterface~T~ <|-- ResourceGuide~T~
    ResourceGuideInterface~T~ <|-- BuiltInResource~T~ : "Delegates to previous"
    ResourceGuideInterface~T~ <|-- ModifiableResource~T~ : "Delegates to previous"
   
    class ResourceGuide~T~{
        <<abstract>>
        +toObject(String content) T
        +toObjectThrows(String content) T*
        +toString(T) String*
        +getEmpty() T*
    }

    ResourceGuide~JSONObject~ <|-- JsonType : JSONObject
    class JsonType{
        + toObjectThrows(String content) JSONObject
        + toString(JSONObject content) String
        + getEmpty() JSONObject
    }

    ResourceGuide~T~ o-- BuiltInResource~T~ 
    class BuiltInResource~T~{
        <<abstract>>
        + getBuiltIn() T
        # buildBuiltIn() T*
    }

    BuiltInResource~T~ <|-- BuiltInResourceFile~T~ 
    class BuiltInResourceFile~T~{
        # buildBuiltIn() T
    }

    BuiltInResource~T~ o-- ModifiableResource~T~
    class ModifiableResource~T~{
        <<abstract>>
        + getCatalog() T
        + clear ()
    }

    ModifiableResource~T~ <|-- ManualEditResource~T~
    class ManualEditResource~T~{
        + save()
    }

    ModifiableResource~T~ <|-- UpdateableResource~T~
    class UpdateableResource~T~{
        + _update(boolean background)
    }
    
    UpdateableResource~T~ <|-- AutoUpdateableResource~T~
    class AutoUpdateableResource~T~{
        + updateIfNecessary()
    }

```
Here is an example to show the actual use.

1. Create a guide to the extension, used for transforming to string/object (this way we can support other fomats like xml)
2. Create a builtin source, either a read only file (from the assets folder) or dynamically built, like the patterns checker module
3. The way this resource will be modified, either manually by the user or it updates from the internet, which can be automatic.

```java
Activity context = null;
// ClearUrls like example
// first, the extension
var type = new JsonGuide();
// second, the builtin source, in this case a file
BuiltInResource<JSONObject> fallback = new BuiltInResourceFile<>(
        context, type, "built-in.json");
// third, how the resource will be modified, in this case it auto downloads
ModifiableResource<JSONObject> modifiable = new AutoUpdateableResource<>(
        fallback, "auto-example.json",
        "example-module",
        "http://fake.domain/catalog",
        "http://fake.domain/hash",
        /*built-in.json-timestamp*/777L/*built-in.json-timestamp*/,
        JavaUtils.weeksToMillis(1));


// Pattern url like example
// first, the extension
type = new JsonGuide();
// second, the builtin source, in this case dynamically built
fallback = new BuiltInResource<>(
        context, type) {
    @Override
    protected JSONObject buildBuiltIn() throws Exception {
        return new JSONObject()

                // built from the translated strings
                .put(context.getString(R.string.mPttrn_ascii), new JSONObject()
                        .put("regex", "[^\\p{ASCII}]")
                )
                .put(context.getString(R.string.mPttrn_http), new JSONObject()
                        .put("regex", "^http://")
                        .put("replacement", "https://")
                )
                ;
    }
};
// third, how the resource will be modified, in this case, manual edit
modifiable = new ManualEditResource<>(
        fallback,"manual-example.json");
```

If you like this change, let me know and I will keep working on the things that will need to be done in order for this to work:
- Change all current implementations of retrieving data from resources, which . Doesn't need to be done all at the same time.
  - JsonCatalog hopefully (only requires changing one variable, hopefully)
    - AutomationRules
    - HostCatalogs
    - PatternCatalog
  - ClearUrlCatalog
- Add an auto migration system (sidetracking again!)
  - Only affects the ClearURLs module, as it stores in the same file both, the updateable catalog and the rules made by the user. The new resource system forces both to be different files.


Let me know what you think! And don't worry if you feel like all this should be scrapped, it is a huge change.