### PR TITLE
Allow an array or a value in automations regex field

### DIFF
--- a/app/src/main/java/com/trianguloy/urlchecker/modules/AutomationRules.java
+++ b/app/src/main/java/com/trianguloy/urlchecker/modules/AutomationRules.java
@@ -10,6 +10,7 @@ import com.trianguloy.urlchecker.utilities.generics.JsonCatalog;
 import com.trianguloy.urlchecker.utilities.methods.AndroidUtils;
 import com.trianguloy.urlchecker.utilities.methods.JavaUtils;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -73,11 +74,17 @@ public class AutomationRules extends JsonCatalog {
                 var automation = catalog.getJSONObject(key);
                 if (!automation.optBoolean("enabled", true)) continue;
 
-                if (urlData.url.matches(automation.getString("regex"))) {
-                    matches.add(automation.getString("action"));
+                for (String pattern : JavaUtils.getArrayOrElement(automation.get("regex"), String.class)){
+                    if (urlData.url.matches(pattern)) {
+                        matches.add(automation.getString("action"));
+                        break;
+                    }
                 }
+
             } catch (JSONException e) {
                 AndroidUtils.assertError("Invalid automation rule", e);
+            } catch (ClassCastException e) {
+                AndroidUtils.assertError("Invalid automation regex", e);
             }
         }
         return matches;

--- a/app/src/main/java/com/trianguloy/urlchecker/utilities/methods/JavaUtils.java
+++ b/app/src/main/java/com/trianguloy/urlchecker/utilities/methods/JavaUtils.java
@@ -1,5 +1,6 @@
 package com.trianguloy.urlchecker.utilities.methods;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -34,6 +35,44 @@ public interface JavaUtils {
         } catch (JSONException e) {
             // invalid catalog, return empty
             return new JSONObject();
+        }
+    }
+
+    /**
+     * Given an {@link Object} gotten from {@link JSONObject#get(String)} and a {@link Class},
+     * it will check if the object is either a value or an array, of said class and return it
+     * as a list.
+     *
+     * @throws ClassCastException if the values are not from type {@code T}
+     */
+    static <T> List<T> getArrayOrElement(Object object, Class<T> clazz) throws ClassCastException, JSONException {
+        List<T> result = new ArrayList<T>();
+
+        if (object instanceof JSONArray array) {
+            // List
+            for (int i = 0; i < array.length(); i++) {
+                result.add(getAsOrCrash(array.get(i), clazz));
+            }
+        } else {
+            // Value
+            result.add(getAsOrCrash(object, clazz));
+        }
+
+        return result;
+    }
+
+    // I don't like it but it wasn't throwing an exception when wrongly casting,
+    // probably due to type casting
+    /**
+     * Returns the value as type {@code T} if possible, if not, it throws an exception
+     *
+     * @throws ClassCastException if the values are not from type {@code T}
+     */
+    static <T> T getAsOrCrash(Object object, Class<T> clazz) throws ClassCastException{
+        if (clazz.isInstance(object)) {
+            return (T) object;
+        } else {
+            throw new ClassCastException("Not of class " + clazz.getName());
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -160,7 +160,7 @@ Hope you find the app useful! And don't hesitate to suggest features, report bug
     <string name="auto_error_toast">Show toast if automation fails</string>
     <string name="auto_notFound">"No automation with key '%s' is available. Make sure it is valid and the required module is active."</string>
     <string name="auto_editor">"Automations configuration. Format: list of objects where the key is a unique automation name and the content includes the following values:
-- 'regex': string, required: a valid java regex that the url must match for the automation to run.
+- 'regex': string|list, required: a valid java regex that the url must match for the automation to run. If list, at least one regex must match.
 - 'action': string, required: the key of the automation to run. Check below for a list of all the available keys.
 - 'enabled': boolean, optional: if false this automation will be skipped. True by default."</string>
     <string name="auto_available_prefix">Available automation actions (keys):</string>


### PR DESCRIPTION
Mentioned in #360 .

In the Automations, the regex field now allows use of both, arrays of Strings or a single String value.
Makes it easier to maintain a big file and more is accessible to add/remove regex to an individual rule.